### PR TITLE
Update ExcludeByIgnoreFileBranchBuildStrategy.java

### DIFF
--- a/src/main/java/com/igalg/jenkins/plugins/multibranch/buildstrategy/ExcludeByIgnoreFileBranchBuildStrategy.java
+++ b/src/main/java/com/igalg/jenkins/plugins/multibranch/buildstrategy/ExcludeByIgnoreFileBranchBuildStrategy.java
@@ -96,7 +96,7 @@ public class ExcludeByIgnoreFileBranchBuildStrategy extends BranchBuildStrategyE
             SCMFile file = fileSystem.getRoot().child(ignorefilePath);
             if(file == null || !file.exists() || !file.isFile()) {
             	logger.severe("File:" + ignorefilePath + " not found");
-            	
+            	return true;
             }
             
             		


### PR DESCRIPTION
Because FileNotFoundException with no `.jenkinsignore`:
```
File:.jenkinsignore not found

Aug 31, 2023 4:21:02 PM SEVERE com.igalg.jenkins.plugins.multibranch.buildstrategy.ExcludeByIgnoreFileBranchBuildStrategy isAutomaticBuild

Unecpected exception
java.io.FileNotFoundException
	at jenkins.plugins.git.GitSCMFile.lambda$content$2(GitSCMFile.java:163)
	at jenkins.plugins.git.GitSCMFileSystem.lambda$invoke$e8567d7e$1(GitSCMFileSystem.java:185)
	at org.jenkinsci.plugins.gitclient.AbstractGitAPIImpl.withRepository(AbstractGitAPIImpl.java:28)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.withRepository(CliGitAPIImpl.java:83)
	at jenkins.plugins.git.GitSCMFileSystem.invoke(GitSCMFileSystem.java:185)
	at jenkins.plugins.git.GitSCMFile.content(GitSCMFile.java:157)
	at jenkins.scm.api.SCMFile.contentAsString(SCMFile.java:335)
	at com.igalg.jenkins.plugins.multibranch.buildstrategy.ExcludeByIgnoreFileBranchBuildStrategy.isAutomaticBuild(ExcludeByIgnoreFileBranchBuildStrategy.java:103)
	at jenkins.branch.BranchBuildStrategy.automaticBuild(BranchBuildStrategy.java:260)
	at jenkins.branch.buildstrategies.basic.AllBranchBuildStrategyImpl.isAutomaticBuild(AllBranchBuildStrategyImpl.java:99)
	at jenkins.branch.BranchBuildStrategy.automaticBuild(BranchBuildStrategy.java:250)
	at jenkins.branch.MultiBranchProject$SCMHeadObserverImpl.isAutomaticBuild(MultiBranchProject.java:2324)
	at jenkins.branch.MultiBranchProject$SCMHeadObserverImpl.doAutomaticBuilds(MultiBranchProject.java:2270)
	at jenkins.branch.MultiBranchProject$SCMHeadObserverImpl.observeExisting(MultiBranchProject.java:2070)
	at jenkins.branch.MultiBranchProject$SCMHeadObserverImpl.observe(MultiBranchProject.java:2021)
	at jenkins.scm.api.SCMHeadObserver$Wrapped.observe(SCMHeadObserver.java:637)
	at jenkins.scm.api.SCMHeadEvent$Validated.observe(SCMHeadEvent.java:295)
	at jenkins.scm.api.trait.SCMSourceRequest.process(SCMSourceRequest.java:357)
	at jenkins.scm.api.trait.SCMSourceRequest.process(SCMSourceRequest.java:249)
	at org.jenkinsci.plugin.gitea.GiteaSCMSource.retrieve(GiteaSCMSource.java:386)
	at jenkins.scm.api.SCMSource._retrieve(SCMSource.java:372)
	at jenkins.scm.api.SCMSource.fetch(SCMSource.java:326)
	at jenkins.branch.MultiBranchProject$SCMEventListenerImpl.processHeadUpdate(MultiBranchProject.java:1614)
	at jenkins.branch.MultiBranchProject$SCMEventListenerImpl.onSCMHeadEvent(MultiBranchProject.java:1218)
	at jenkins.scm.api.SCMHeadEvent$DispatcherImpl.fire(SCMHeadEvent.java:246)
	at jenkins.scm.api.SCMHeadEvent$DispatcherImpl.fire(SCMHeadEvent.java:229)
	at jenkins.scm.api.SCMEvent$Dispatcher.run(SCMEvent.java:545)
	at jenkins.security.ImpersonatingScheduledExecutorService$1.run(ImpersonatingScheduledExecutorService.java:67)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)


```