### PR TITLE
Using GitHub as source for documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,9 @@
     <packaging>hpi</packaging>
     <name>Pipeline: Multibranch build strategy extension</name>
 
-    <description>This plugin provides additional configuration for multi branch build strategies.</description>
+    <description>This plugin provides additional configuration for multibranch build strategies.</description>
 
-    <url>https://wiki.jenkins.io/display/JENKINS/Multibranch+Build+Strategy+Extension+Plugin</url>
+    <url>https://github.com/jenkinsci/multibranch-build-strategy-extension-plugin</url>
 
     <properties>
         <revision>1.1.0</revision>


### PR DESCRIPTION
Following [Plugin Documentation-as-Code: Moving docs to GitHub ](https://www.jenkins.io/blog/2019/10/21/plugin-docs-on-github/) to have the documentation displayed at https://plugins.jenkins.io/multibranch-build-strategy-extension/ from GitHub

### Testing done

None

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```