### PR TITLE
Rely on plugin BOM to declare plugin version dependencies

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.7</version>
+    <version>1.8</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.80</version>
+        <version>4.88</version>
         <relativePath />
     </parent>
 
@@ -23,9 +23,8 @@
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/multibranch-build-strategy-extension</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.426</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-        <java.level>17</java.level>
+        <jenkins.baseline>2.452</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
     </properties>
 
     <licenses>
@@ -73,7 +72,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>2961.v1f472390972e</version>
+                <version>3944.v1a_e4f8b_452db_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
     </developers>
 
     <scm>
-        <connection>scm:git:ssh://git@github.com/${gitHubRepo}.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
         <url>https://github.com/${gitHubRepo}.git</url>
         <tag>${scmTag}</tag>
     </scm>

--- a/pom.xml
+++ b/pom.xml
@@ -83,20 +83,14 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>683.vb_16722fb_b_80b_</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>5.2.1</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
-            <version>2.1152.v6f101e97dd77</version>
-            <scope>compile</scope>
         </dependency>
 
         <!-- TESTS -->
@@ -108,21 +102,18 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1265.v65b_14fa_f12f0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
             <classifier>tests</classifier>
-            <version>5.2.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
             <classifier>tests</classifier>
-            <version>689.v237b_6d3a_ef7f</version>
             <scope>test</scope>
         </dependency>
 
@@ -166,31 +157,26 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1326.vdb_c154de8669</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-branch-source</artifactId>
-            <version>1785.v99802b_69816c</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>400.v35420b_922dcb_</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-bitbucket-branch-source</artifactId>
-            <version>883.v041fa_695e9c2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>pipeline-groovy-lib</artifactId>
-            <version>704.vc58b_8890a_384</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Rely on plugin BOM to declare plugin version dependencies

The plugin bill of materials (BOM) defines the versions of various plugins used by specific Jenkins versions. The plugin bill of materials includes many commonly used plugins and simplifies dependency management for plugins that depend on other plugins.

Remove the version declarations in the plugin pom file and rely on the versions that are tested together in the plugin bill of materials.

The [dependency management documentation](https://www.jenkins.io/doc/developer/plugin-development/dependency-management/) provides more details.

Replaces the following pull requests and will avoid needing to process most of those types of pull requests in the future:

* https://github.com/jenkinsci/multibranch-build-strategy-extension-plugin/pull/37
* https://github.com/jenkinsci/multibranch-build-strategy-extension-plugin/pull/39
* https://github.com/jenkinsci/multibranch-build-strategy-extension-plugin/pull/41
* https://github.com/jenkinsci/multibranch-build-strategy-extension-plugin/pull/42
* https://github.com/jenkinsci/multibranch-build-strategy-extension-plugin/pull/44
* https://github.com/jenkinsci/multibranch-build-strategy-extension-plugin/pull/47
* https://github.com/jenkinsci/multibranch-build-strategy-extension-plugin/pull/48

#### Require Jenkins 2.452.4 or newer

The [Jenkins developer documentation](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) recommends Jenkins 2.452.4 or Jenkins 2.462.3 as minimum Jenkins baseline.  Releases prior to Jenkins 2.452.4 have critical security vulnerabilities.  Jenkins users should be running 2.452.4 or newer so that they have those security fixes.

[Plugin installation statistics](https://old.stats.jenkins.io/pluginversions/multibranch-build-strategy-extension.html) show that over 70% of users that have installed the most recent release of this plugin are already running Jenkins 2.452.4.  They will be able to use the new release without updating their Jenkins controller.

Removes the setting of java.level because Java version support is defined by the plugin parent pom.  Jenkins 2.452.4 supports Java 11, Java 17, and Java 21.   Development can be done with any of those Java releases when Jenkins 2.452.4 is the minimum Jenkins version.

Updates the plugin BOM version to the most recent 2.452.x release.

#### Update scm properties to prevent future breakage

The ssh:// protocol for scm.connection is not well supported by the Jenkins plugin bill of materials and its plugin compatibility tester.  Switch to https:// protocol so that access through teh scm.connection does not require an ssh private key.

Use the alternate form of scm.developerConnection ssh URL to silence warnings from the hpi plugin.  Access through scm.developerConnection continues to use ssh.  Since the plugin is now using automated releases, it could be switched to https as well, but that change needs discussion with the plugin maintainer.

### Testing done

Confirmed that automated tests pass on Linux with Java 21.  Reviewed contents of the MANIFEST.MF file in the plugin hpi file and confirmed that the three plugin dependencies were the expected versions to match with Jenkins 2.452.4 and the most recent plugin BOM release for that version of Jenkins.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
