### PR TITLE
During the first build of a change request, compare against the target

### DIFF
--- a/src/main/java/com/igalg/jenkins/plugins/multibranch/buildstrategy/AbstractBranchBuildStrategy.java
+++ b/src/main/java/com/igalg/jenkins/plugins/multibranch/buildstrategy/AbstractBranchBuildStrategy.java
@@ -42,6 +42,7 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
+import jenkins.scm.api.mixin.ChangeRequestSCMRevision;
 
 public abstract class AbstractBranchBuildStrategy extends BranchBuildStrategy {
 
@@ -83,6 +84,11 @@ public abstract class AbstractBranchBuildStrategy extends BranchBuildStrategy {
                 boolean build = strategy == Strategy.EXCLUDED;
                 LOGGER.info(() -> String.format("No pattern with strategy: %s, building=%s", strategy, build));
                 return build;
+            }
+
+            // If this is the first build of a change request, compare against the target.
+            if (lastBuiltRevision == null && currRevision instanceof ChangeRequestSCMRevision) {
+                lastBuiltRevision = ((ChangeRequestSCMRevision) currRevision).getTarget();
             }
 
             // collect all changes from previous build

--- a/src/test/java/com/igalg/jenkins/plugins/multibranch/buildstrategy/AbstractBranchBuildStrategyExtensionTest.java
+++ b/src/test/java/com/igalg/jenkins/plugins/multibranch/buildstrategy/AbstractBranchBuildStrategyExtensionTest.java
@@ -53,6 +53,8 @@ import jenkins.plugins.git.GitSCMSource;
 import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSourceOwner;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.mixin.ChangeRequestSCMRevision;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractBranchBuildStrategyExtensionTest {
@@ -242,6 +244,34 @@ public class AbstractBranchBuildStrategyExtensionTest {
 
             // then
             assertTrue(buildStrategy.isShouldRunBuildExecuted);
+        }
+    }
+
+    @Test
+    public void should_return_FALSE_when_patternsPresentAndStrategyExcludedAndlastBuiltRevisionNull() {
+        // given
+        Set<String> excludedRegions = Sets.newHashSet("*.md");
+        Set<String> paths = Sets.newHashSet("README.md");
+        TestBranchBuildStrategy buildStrategy = new TestBranchBuildStrategy(EXCLUDED, excludedRegions, paths);
+
+        SCM scm = mock(SCM.class);
+
+        GitSCMFileSystem fileSystem = mock(GitSCMFileSystem.class);
+
+        SCMSourceOwner owner = mock(SCMSourceOwner.class);
+        given(source.getOwner()).willReturn(owner);
+
+        SCMRevision lastBuiltRevisionNull = null;
+        ChangeRequestSCMRevision currRevision = mock(ChangeRequestSCMRevision.class);
+
+        try (MockedStatic<BranchBuildStrategyHelper> mockedHelper = mockStatic(BranchBuildStrategyHelper.class)) {
+            mockedHelper.when(() -> BranchBuildStrategyHelper.buildSCMFileSystem(source, head, currRevision, scm, owner)).thenReturn(fileSystem);
+
+            // when
+            buildStrategy.isAutomaticBuild(source, head, currRevision, lastBuiltRevisionNull, lastSeenRevision, listener);
+
+            // then
+            assertFalse(buildStrategy.isShouldRunBuildExecuted);
         }
     }
 }


### PR DESCRIPTION
When performing the first build of a merge request, compare the merge request revision against the target branch revision.

This addresses the following Jira issues: [JENKINS-67128](https://issues.jenkins.io/browse/JENKINS-67128) [JENKINS-60882](https://issues.jenkins.io/browse/JENKINS-60882)

### Testing done

Built and installed this new version on running Jenkins and verified that initial merge request build is only automatically triggered when the configured condition matches.